### PR TITLE
Add Swift package manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "RHSideButtons",
+    platforms: [.iOS(.v8)],
+    products: [
+        .library(name: "RHSideButtons", targets: ["RHSideButtons"])
+    ],
+    targets: [
+        .target(name: "RHSideButtons", path: "RHSideButtons/RHSideButtons")
+    ]
+)


### PR DESCRIPTION
Requires the Swift update of the PR #27 to be merged first to work with Xcode.